### PR TITLE
Feature/backend/member front

### DIFF
--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -50,11 +50,11 @@ const routes = [
     component: () =>
       import('../views/admin/AdminOrderIndex.vue')
   }, {
-    path: '/admin/order/:categoryId',
-    name: 'admin-order-category',
-    component: () =>
-      import('../views/admin/AdminOrderCategory.vue')
-  }, {
+    //   path: '/admin/order/:categoryId',
+    //   name: 'admin-order-category',
+    //   component: () =>
+    //     import('../views/admin/AdminOrderCategory.vue')
+    // }, {
     path: '/admin/manage/members',
     name: 'admin-manage-members',
     component: () =>

--- a/server/config/config.json
+++ b/server/config/config.json
@@ -7,7 +7,8 @@
     "dialect": "mysql"
   },
   "test": {
-    "username": "travis",
+    "username": "root",
+    "password": "password",
     "database": "recus_platform_test",
     "host": "127.0.0.1",
     "dialect": "mysql",

--- a/server/config/config.json
+++ b/server/config/config.json
@@ -7,8 +7,7 @@
     "dialect": "mysql"
   },
   "test": {
-    "username": "root",
-    "password": "password",
+    "username": "travis",
     "database": "recus_platform_test",
     "host": "127.0.0.1",
     "dialect": "mysql",

--- a/server/controllers/admin/dashboardController.js
+++ b/server/controllers/admin/dashboardController.js
@@ -1,6 +1,20 @@
 const db = require('../../models')
 const moment = require('moment')
-const { Order, DishCombination, Tag, Dish, User, Profile } = db
+const { Order, DishCombination, Tag, Dish, User, Profile, UserPreferred } = db
+
+// 使天數的組數一致
+function timeAxis(days, Chart) {
+  Object.values(Chart).forEach(item => {
+    Object.keys(days).map(day => {
+      if (!(day in item)) {
+        item[day] = {
+          count: 0
+        }
+      }
+    })
+  })
+}
+
 
 const dashboardController = {
 
@@ -90,7 +104,7 @@ const dashboardController = {
       // 篩選與排序購買數前五名的會員
       hotMembers = Object.values(hotMembers).sort((a, b) => (b.count - a.count)).slice(0, 5)
 
-      return res.json({ hotProducts: hotProducts, hotTags: hotTags, hotMembers: hotMembers, data: users, data2: dishes })
+      return res.json({ hotProducts: hotProducts, hotTags: hotTags, hotMembers: hotMembers, data1: users, data2: dishes })
 
     } catch (error) {
       return res.status(500).json({ status: 'error', msg: error })
@@ -101,9 +115,12 @@ const dashboardController = {
     try {
       let days = {} // 取得天數組
       let pChart = {} // 取得產品成長的成長分析, p 是product的簡寫
-      let tChart = {}
-      if (req.query.range === 'weekly') {
-        products = await DishCombination.scope('weekly').findAll(
+      let uChart = {} // 取得會員拜訪次數的成長分析, u 是user的簡寫
+      let tChart = {} // 取得標籤被會員加入的成長分析, t 是tag的簡寫
+
+      // 產品成長的成長分析
+      if (req.query.type === 'product') {
+        products = await DishCombination.scope(req.query.range).findAll(
           {
             where: { DishId: req.query.id },
             attributes: ['DishId', 'OrderId', 'createdAt'],
@@ -112,74 +129,157 @@ const dashboardController = {
               //include: [{ model: Tag, as: 'hasTags', attributes: ['id', 'name'] }]
             }]
           })
-      }
-      if (req.query.range === 'monthly') {
-        products = await DishCombination.scope('monthly').findAll(
-          {
-            where: { DishId: req.query.id },
-            attributes: ['DishId', 'OrderId', 'createdAt'],
-            include: [{
-              model: Dish, attributes: ['name'],
-              //include: [{ model: Tag, as: 'hasTags', attributes: ['id', 'name'] }]
-            }]
-          })
-      }
-      // 計算前七天內產品成長的折線圖
-      for (let product of products) {
-        let createdAt = moment(product.createdAt).format("MM-DD")
-        // 計算天數組
-        if (!days[createdAt]) days[createdAt] = 1
-        // 沒有產品的key
-        if (!pChart[product.Dish.name]) {
-          pChart[product.Dish.name] = {
-            [createdAt]: {
-              count: 1
+
+        // 計算前七天內產品成長的折線圖
+        for (let product of products) {
+          let createdAt = moment(product.createdAt).format("MM-DD")
+          // 計算天數組
+          if (!days[createdAt]) days[createdAt] = 1
+          // 沒有產品的key
+          if (!pChart[product.Dish.name]) {
+            pChart[product.Dish.name] = {
+              [createdAt]: {
+                count: 1
+              }
             }
-          }
-        } else {
-          // 已有產品的key
-          if (!(createdAt in pChart[product.Dish.name])) {
-            pChart[product.Dish.name][createdAt] = {
-              count: 1
+          } else {
+            // 已有產品的key
+            if (!(createdAt in pChart[product.Dish.name])) {
+              pChart[product.Dish.name][createdAt] = {
+                count: 1
+              }
             }
-          }
-          else {
-            pChart[product.Dish.name][createdAt].count++
+            else {
+              pChart[product.Dish.name][createdAt].count++
+            }
           }
         }
-        // 計算前七天內標籤成長的的折線圖
-        // for (let item of product.Dish.hasTags) {
-        //   if (!tChart[item.name]) {
-        //     tChart[item.name] = {
-        //       [createdAt]: {
-        //         //id: item.id,
-        //         //name: item.name,
-        //         count: 1
-        //       }
-        //     }
-        //   } else {
-        //     if (!(createdAt in tChart[item.name])) {
-        //       tChart[item.name][createdAt] = {
-        //         //id: item.id,
-        //         //name: item.name,
-        //         count: 1
-        //       }
-        //     } else {
-        //       tChart[item.name][createdAt].count++
-        //     }
-        //   }
-        // }
+
+        // 使各產品之中天數的組數一致
+        timeAxis(days, pChart)
+
+        return res.json({ days: Object.keys(days), pChart: pChart, products: products })
       }
-      // 使各產品之中天數的組數一致
-      Object.values(pChart).forEach(product => {
-        Object.keys(days).map(day => {
-          if (!(day in product)) {
-            product[day] = {
-              count: 0
+
+      // 會員拜訪次數的成長分析
+      if (req.query.type === 'user') {
+        users = await Order.scope('orderWithMember', req.query.range).findAll(
+          {
+            where: { UserId: req.query.id },
+            attributes: ['UserId', 'createdAt'],
+            include: [{
+              model: User, attributes: ['id'], where: { role: 'member' },
+              include: [{ model: Profile, attributes: ['name'] }]
+            }]
+          })
+
+        // 計算前七天內會員拜訪次數成長的折線圖
+        for (let user of users) {
+          let createdAt = moment(user.createdAt).format("MM-DD")
+          // 計算天數組
+          if (!days[createdAt]) days[createdAt] = 1
+          // 沒有會員的key
+          if (!uChart[user.User.Profile.name]) {
+            uChart[user.User.Profile.name] = {
+              [createdAt]: {
+                count: 1
+              }
+            }
+          } else {
+            // 已有會員的key
+            if (!(createdAt in uChart[user.User.Profile.name])) {
+              uChart[user.User.Profile.name][createdAt] = {
+                count: 1
+              }
+            }
+            else {
+              uChart[user.User.Profile.name][createdAt].count++
             }
           }
-        })
-      })
+        }
+
+        // 使各會員之天數的組數一致
+        timeAxis(days, uChart)
+
+        return res.json({ days: Object.keys(days), uChart: uChart, users: users })
+      }
+
+      if (req.query.type === 'tag') {
+        tags = await UserPreferred.scope(req.query.range).findAll(
+          {
+            where: { TagId: req.query.id },
+            attributes: ['createdAt'],
+            include: [{
+              model: Tag, attributes: ['name', 'id'],
+              //   include: [{ model: Profile, attributes: ['name'] }]
+            }]
+          })
+
+        // 計算前七天內被收藏標籤成長的折線圖
+        for (let tag of tags) {
+          let createdAt = moment(tag.createdAt).format("MM-DD")
+          // 計算天數組
+          if (!days[createdAt]) days[createdAt] = 1
+          // 沒有標籤的key
+          if (!tChart[tag.Tag.name]) {
+            tChart[tag.Tag.name] = {
+              [createdAt]: {
+                count: 1
+              }
+            }
+          } else {
+            // 已有標籤的key
+            if (!(createdAt in tChart[tag.Tag.name])) {
+              tChart[tag.Tag.name][createdAt] = {
+                count: 1
+              }
+            }
+            else {
+              tChart[tag.Tag.name][createdAt].count++
+            }
+          }
+        }
+
+        // 使各標籤之天數的組數一致
+        timeAxis(days, tChart)
+
+        return res.json({ days: Object.keys(days), tChart: tChart, tags: tags })
+      }
+      // if (req.query.range === 'monthly') {
+      //   products = await DishCombination.scope('monthly').findAll(
+      //     {
+      //       where: { DishId: req.query.id },
+      //       attributes: ['DishId', 'OrderId', 'createdAt'],
+      //       include: [{
+      //         model: Dish, attributes: ['name'],
+      //         //include: [{ model: Tag, as: 'hasTags', attributes: ['id', 'name'] }]
+      //       }]
+      //     })
+      // }
+
+      // 計算前七天內標籤成長的的折線圖
+      // for (let item of product.Dish.hasTags) {
+      //   if (!tChart[item.name]) {
+      //     tChart[item.name] = {
+      //       [createdAt]: {
+      //         //id: item.id,
+      //         //name: item.name,
+      //         count: 1
+      //       }
+      //     }
+      //   } else {
+      //     if (!(createdAt in tChart[item.name])) {
+      //       tChart[item.name][createdAt] = {
+      //         //id: item.id,
+      //         //name: item.name,
+      //         count: 1
+      //       }
+      //     } else {
+      //       tChart[item.name][createdAt].count++
+      //     }
+      //   }
+      // }
+
 
       // 使各標籤之中天數的組數一致
       // Object.values(tChart).forEach(tag => {
@@ -192,9 +292,9 @@ const dashboardController = {
       //   })
       // })
 
-      return res.json({ days: Object.keys(days), pChart: pChart, products: products })
+
     } catch (error) {
-      return res.status(500).json({ status: 'error', msg: error })
+      return res.status(500).json({ status: 'error', msg: 'not found!' })
     }
   }
 }

--- a/server/controllers/admin/dishController.js
+++ b/server/controllers/admin/dishController.js
@@ -1,5 +1,5 @@
 const db = require('../../models')
-const { Dish, DishAttachment, Category } = db
+const { Dish, DishAttachment, Category, Tag } = db
 //const Category = db.Category
 
 
@@ -15,7 +15,7 @@ const dishController = {
         CategoryId: req.query.categoryId
       }
 
-      return Dish.findAll({ where: whereQuery }).then(dishes => {
+      Dish.findAll({ where: whereQuery }).then(dishes => {
         return res.json({ dishes: dishes })
       })
     } catch (error) {
@@ -29,9 +29,9 @@ const dishController = {
       if (Number(req.params.categoryId) < 1) {
         return res.json({ status: 'error', msg: 'undefined dish id' })
       }
-
-      return Dish.findByPk(req.params.id,
-        { include: [Category, { model: db.Tag, as: 'hasTags' }] }).then(dish => {
+      Dish.findByPk(req.params.id,
+        { include: [Category, { model: Tag, as: 'hasTags', through: { attributes: [] } }] })
+        .then(dish => {
           return res.json({ dish: dish })
         })
     } catch (error) {

--- a/server/controllers/admin/memberController.js
+++ b/server/controllers/admin/memberController.js
@@ -1,6 +1,6 @@
 const bcrypt = require('bcryptjs')
 const db = require('../../models')
-const { User, Profile, Order, MemberOrder, Tag, UserPreferred } = db
+const { User, Profile, Order, MemberOrder, Tag, UserPreferred, Dish } = db
 const Op = require('sequelize').Op
 const moment = require('moment')
 
@@ -79,7 +79,10 @@ const memberController = {
       // 取出單一會員
       User.scope('getMemberData').findByPk(req.params.id,
         {
-          include: [{ model: Tag, as: 'preferredTags' }]
+          include: [{
+            model: Tag, as: 'preferredTags', attributes: ['name'],
+            through: { attributes: [] }
+          }]
         }).then(user => {
           if (!user) return res.json({ status: 'error', msg: 'no such user!' })
           return res.json({ user: user })
@@ -115,16 +118,20 @@ const memberController = {
       // 取出單一會員
       Order.findAll(
         {
-          attributes: ['amount', 'quantity', 'createdAt'],
+          attributes: ['id', 'amount', 'quantity', 'createdAt'],
+          include: [{
+            model: Dish, as: 'sumOfDishes', attributes: ['name']
+            , through: { attributes: [] }
+          }],
           where: { UserId: req.params.id },
           order: [['createdAt', 'DESC']]
         }).then(orders => {
           if (!orders) return res.json({ status: 'error', msg: 'no such user!' })
           // 訂單資料整理
-          orders = orders.map(order => ({
-            ...order.dataValues,
-            createdAt: moment(order.createdAt).format('YYYY-MM-DD HH:mm')
-          }))
+          // orders = orders.map(order => ({
+          //   ...order.dataValues,
+          //   createdAt: moment(order.createdAt).format('YYYY-MM-DD HH:mm')
+          // }))
           return res.json({ orders: orders })
         })
     } catch (error) {

--- a/server/controllers/member/orderController.js
+++ b/server/controllers/member/orderController.js
@@ -1,6 +1,6 @@
 // const helper = require('../../_helpers')
 const db = require('../../models')
-const { Order, Dish, DishCombination } = db
+const { Order, Dish, DishCombination, Category, Tag } = db
 
 const orderController = {
   addOrder: async (req, res) => {
@@ -74,7 +74,36 @@ const orderController = {
     } catch (error) {
       return res.status(500).json({ status: 'error', msg: error })
     }
-  }
+  },
+
+  getCategories: (req, res) => {
+    try {
+      Category.findAll().then(categories => {
+        return res.json({ categories: categories })
+      })
+    } catch (error) {
+      return res.status(500).json({ status: 'error', msg: error })
+    }
+  },
+
+  // 取得某分類的所有品項
+  getDishWithCategory: (req, res) => {
+    try {
+      if (Number(req.query.categoryId) < 1) {
+        return res.json({ status: 'error', msg: 'undefined category id' })
+      }
+
+      Dish.findAll({
+        where: { CategoryId: req.query.categoryId },
+        attributes: ['id', 'name', 'price', 'image', 'description'],
+        include: [{ model: Tag, as: 'hasTags', attributes: ['name'] }]
+      }).then(dishes => {
+        return res.json({ dishes: dishes })
+      })
+    } catch (error) {
+      return res.status(500).json({ status: 'error', msg: error })
+    }
+  },
 }
 
 module.exports = orderController

--- a/server/models/dishcombination.js
+++ b/server/models/dishcombination.js
@@ -14,16 +14,16 @@ module.exports = (sequelize, DataTypes) => {
         weekly: {
           where: {
             createdAt: {
-              [Op.gte]: moment().subtract(7, 'days').hours(0)
-              , [Op.lte]: moment().subtract(1, 'days').hours(23)
+              [Op.gte]: moment().subtract(1, 'weeks').startOf('week')
+              , [Op.lte]: moment().subtract(1, 'weeks').endOf('week')
             }
           }
         },
         monthly: {
           where: {
             createdAt: {
-              [Op.gte]: moment().subtract(30, 'days')
-              , [Op.lte]: moment().subtract(1, 'days')
+              [Op.gte]: moment().subtract(1, 'months').startOf('month')
+              , [Op.lte]: moment().subtract(1, 'months').endOf('month')
             }
           }
         }

--- a/server/models/order.js
+++ b/server/models/order.js
@@ -17,7 +17,7 @@ module.exports = (sequelize, DataTypes) => {
         //paranoid: false
       },
       scopes: {
-        orderWithMember: {
+        orderWithoutMember: {
           where: {
             UserId: { [Op.gt]: 0 }
           }

--- a/server/models/order.js
+++ b/server/models/order.js
@@ -17,7 +17,7 @@ module.exports = (sequelize, DataTypes) => {
         //paranoid: false
       },
       scopes: {
-        orderWithoutMember: {
+        orderWithMember: {
           where: {
             UserId: { [Op.gt]: 0 }
           }
@@ -25,24 +25,24 @@ module.exports = (sequelize, DataTypes) => {
         todayOrder: {
           where: {
             createdAt: {
-              [Op.gte]: moment().hour(0)//new Date().setHours(0, 0, 0)
-              , [Op.lte]: moment().hour(23)
+              [Op.gte]: moment().startOf('day')//new Date().setHours(0, 0, 0)
+              , [Op.lte]: moment().endOf('day')
             }
           }
         },
         weekly: {
           where: {
             createdAt: {
-              [Op.gte]: moment().subtract(7, 'days').hours(0)
-              , [Op.lte]: moment().subtract(1, 'days').hours(23)
+              [Op.gte]: moment().subtract(1, 'weeks').startOf('week')
+              , [Op.lte]: moment().subtract(1, 'weeks').endOf('week')
             }
           }
         },
         monthly: {
           where: {
             createdAt: {
-              [Op.gte]: moment().subtract(30, 'days')
-              , [Op.lte]: moment().subtract(1, 'days')
+              [Op.gte]: moment().subtract(1, 'months').startOf('month')
+              , [Op.lte]: moment().subtract(1, 'months').endOf('month')
             }
           }
 

--- a/server/models/userpreferred.js
+++ b/server/models/userpreferred.js
@@ -1,11 +1,34 @@
 'use strict';
+const Op = require('sequelize').Op
+const moment = require('moment')
+
 module.exports = (sequelize, DataTypes) => {
   const UserPreferred = sequelize.define('UserPreferred', {
     TagId: DataTypes.INTEGER,
     UserId: DataTypes.INTEGER
-  }, {});
+  }, {
+      scopes: {
+        weekly: {
+          where: {
+            createdAt: {
+              [Op.gte]: moment().subtract(1, 'weeks').startOf('week')
+              , [Op.lte]: moment().subtract(1, 'weeks').endOf('week')
+            }
+          }
+        },
+        monthly: {
+          where: {
+            createdAt: {
+              [Op.gte]: moment().subtract(1, 'months').startOf('month')
+              , [Op.lte]: moment().subtract(1, 'months').endOf('month')
+            }
+          }
+
+        },
+      }
+    });
   UserPreferred.associate = function (models) {
-    // associations can be defined here
+    UserPreferred.belongsTo(models.Tag)
   };
   return UserPreferred;
 };

--- a/server/routes/api/adminRoute.js
+++ b/server/routes/api/adminRoute.js
@@ -11,7 +11,7 @@ const { nameValidRules, dishValidRules, validate } = require('../../controllers/
 
 
 // 會員相關API
-router.get('/user', userController.getCurrentUser)
+// router.get('/user', userController.getCurrentUser)
 router.get('/members', memberController.getMemberPagination)
 router.get('/members/:id/orders', memberController.getMemberOrders)
 router.get('/members/:id/tags', memberController.getMemberTags)

--- a/server/routes/api/adminRoute.js
+++ b/server/routes/api/adminRoute.js
@@ -55,7 +55,8 @@ router.put('/categories/:id', nameValidRules(), validate, categoryController.upd
 router.delete('/categories/:id', categoryController.removeCategory)
 
 // 儀表板相關API
-router.get('/dashboard', dashboardController.getDashboard)
+router.get('/dashboard', dashboardController.getBasicInfo)
+router.get('/dashboard/pieChart', dashboardController.getPieChart)
 router.get('/dashboard/lineChart', dashboardController.getLineChart)
 
 module.exports = router

--- a/server/routes/api/index.js
+++ b/server/routes/api/index.js
@@ -34,6 +34,6 @@ const authAdmin = (req, res, next) => {
 module.exports = (app) => {
   //app.use('/api/test', (req, res) => { return res.send('hello!')})
   app.use('/api/', main)
-  app.use('/api/member', authenticated, getUser, authMember, member)
+  app.use('/api/member', authenticated, getUser, member)
   app.use('/api/admin', authenticated, getUser, authAdmin, admin)
 }

--- a/server/routes/api/mainRoute.js
+++ b/server/routes/api/mainRoute.js
@@ -7,5 +7,7 @@ const { signupValidationRules, signinValidRules, validate } = require('../../con
 router.post('/signup', signupValidationRules(), validate, userController.signUp)
 router.post('/signin', signinValidRules(), validate, userController.signIn)
 router.get('/test', (req, res) => { res.json({ status: 'success', msg: 'successfully connected' }) })
+// 無驗證版
+router.get('/user', userController.getCurrentUser)
 
 module.exports = router

--- a/server/routes/api/memberRoute.js
+++ b/server/routes/api/memberRoute.js
@@ -18,4 +18,8 @@ router.delete('/mypreferred', memberController.removeMyPreferred)
 router.get('/orders', orderController.getMyOrders)
 router.post('/orders', orderController.addOrder)
 
+// 取得分類與訂單相關API
+router.get('/categories', orderController.getCategories)
+router.get('/dishes', orderController.getDishWithCategory)
+
 module.exports = router

--- a/server/test/requests/Dashboard.spec.js
+++ b/server/test/requests/Dashboard.spec.js
@@ -68,9 +68,9 @@ const orders = [
   }
 
 ]
-const member1 = { account: 'user1', phone: '0901', password: '12345', role: 'admin' }
-const member2 = { account: 'user2', phone: '0902', password: '12345', role: 'member' }
-const member3 = { account: 'user3', phone: '0903', password: '12345', role: 'member' }
+const member1 = { id: 1, account: 'user1', phone: '0901', password: '12345', role: 'admin' }
+const member2 = { id: 2, account: 'user2', phone: '0902', password: '12345', role: 'member' }
+const member3 = { id: 3, account: 'user3', phone: '0903', password: '12345', role: 'member' }
 const profi1 = { name: 'nacho', email: 'nacho@example.com', UserId: 2 }
 const profi2 = { name: 'kirwen', email: 'kirwen@example.com', UserId: 3 }
 const userPreferred = [{ TagId: 1, UserId: 2 }, { TagId: 8, UserId: 3 }, { TagId: 3, UserId: 2 }

--- a/server/test/requests/Dashboard.spec.js
+++ b/server/test/requests/Dashboard.spec.js
@@ -10,11 +10,18 @@ var should = chai.should();
 var expect = chai.expect;
 const db = require('../../models')
 const moment = require('moment')
+moment.locale('zh_TW')
 var tk = require('timekeeper')
 const nowTime = new Date()
-const time1 = moment(nowTime, "YYYY-M-D H:m").subtract(1, 'weeks').day(1).toDate() //moment().subtract(1, 'days')
+
+const time1 = moment(nowTime, "YYYY-M-D H:m").subtract(1, 'weeks').day(1).toDate()
 const time2 = moment(nowTime, "YYYY-M-D H:m").subtract(1, 'weeks').day(2).toDate()
 const time3 = moment(nowTime, "YYYY-M-D H:m").subtract(1, 'weeks').day(3).toDate()
+
+const time4 = moment(nowTime, "YYYY-M-D H:m").subtract(5, 'weeks').day(1).toDate()
+const time5 = moment(nowTime, "YYYY-M-D H:m").subtract(6, 'weeks').day(1).toDate()
+const time6 = moment(nowTime, "YYYY-M-D H:m").subtract(7, 'weeks').day(1).toDate()
+
 const tags = ["淺焙", "中焙", "深焙", "衣索比亞", "肯亞", "印尼", "微果酸", "果香味", "手沖", "義式機", "新品"] // 11
 const menu = [
   { name: '黑框美式', price: 60, CategoryId: 1, tags: [{ id: 3 }, { id: 10 }, { id: 11 }] },
@@ -70,7 +77,7 @@ const userPreferred = [{ TagId: 1, UserId: 2 }, { TagId: 8, UserId: 3 }, { TagId
   , { TagId: 1, UserId: 3 }, { TagId: 4, UserId: 2 }, { TagId: 10, UserId: 2 }]
 
 describe('# Admin::Dashboard Request', () => {
-  context('go to Dashboard feature', () => {
+  context('go to Dashboard feature(weekly)', () => {
 
     before(async () => {
       this.ensureAuthenticated = sinon.stub(
@@ -79,18 +86,11 @@ describe('# Admin::Dashboard Request', () => {
       this.getUser = sinon.stub(
         helpers, 'getUser'
       ).returns({ id: 1, role: 'admin' })
-      await db.Tag.destroy({ where: {}, truncate: true })
-      await db.Dish.destroy({ where: {}, truncate: true })
-      await db.Order.destroy({ where: {}, force: true, truncate: true })
-      await db.User.destroy({ where: {}, force: true, truncate: true })
-      await db.UserPreferred.destroy({ where: {}, truncate: true })
-      await db.DishCombination.destroy({ where: {}, truncate: true })
-      await db.DishAttachment.destroy({ where: {}, truncate: true })
-      await db.Profile.destroy({ where: {}, truncate: true })
+
       tk.freeze(nowTime)
-      await tags.forEach(tag => {
-        db.Tag.create({ name: tag })
-      })
+      for (let i = 0; i < tags.length; i++) {
+        await db.Tag.create({ name: tags[i] })
+      }
       for (let i = 0; i < orders.length; i++) {
         let curretnTime
         if (i < 2) {
@@ -103,19 +103,20 @@ describe('# Admin::Dashboard Request', () => {
         await db.Order.create({
           quantity: orders[i].quantity, amount: orders[i].amount, createdAt: curretnTime,
           memo: orders[i].memo, isTakingAway: orders[i].isTakingAway, UserId: orders[i].UserId
-        }).then(item => {
-          orders[i].dishes.forEach(dish => {
-            return db.DishCombination.create({ OrderId: item.id, DishId: dish.id, perQuantity: dish.quantity, perAmount: dish.price, createdAt: curretnTime })
-          })
         })
+        for (let j = 0; j < orders[i].dishes.length; j++) {
+          await db.DishCombination.create({
+            OrderId: i + 1, DishId: orders[i].dishes[j].id,
+            perQuantity: orders[i].dishes[j].quantity, perAmount: orders[i].dishes[j].price,
+            createdAt: curretnTime
+          })
+        }
       }
       for (let i = 0; i < menu.length; i++) {
-        await db.Dish.create({ name: menu[i].name, price: menu[i].price, CategoryId: menu[i].CategoryId })
-          .then(dish => {
-            menu[i].tags.forEach(tag => {
-              return db.DishAttachment.create({ TagId: tag.id, DishId: dish.id })
-            })
-          })
+        dish = await db.Dish.create({ name: menu[i].name, price: menu[i].price, CategoryId: menu[i].CategoryId })
+        for (let j = 0; j < menu[i].tags.length; j++) {
+          await db.DishAttachment.create({ TagId: menu[i].tags[j].id, DishId: i + 1 })
+        }
       }
       for (let i = 0; i < userPreferred.length; i++) {
         let currentTime
@@ -165,10 +166,7 @@ describe('# Admin::Dashboard Request', () => {
             // console.log(time1)
             // console.log(time2)
             // console.log(time3)
-            // console.log(res.body.data1)
-            // console.log(res.body.hotProducts)
-            // console.log(res.body.hotMembers)
-            // console.log(res.body.hotTags)
+            // console.log(res.body)
             expect(res.body.hotProducts[0]).to.eql({ id: 1, name: '黑框美式', count: 4 })
             expect(res.body.hotProducts.length).to.be.equal(5)
             expect(res.body.hotMembers[0]).to.eql({ id: 2, name: 'nacho', count: 4 })
@@ -185,9 +183,7 @@ describe('# Admin::Dashboard Request', () => {
           .expect(200)
           .end((err, res) => {
             if (err) return done(err)
-            // console.log(res.body.days)
-            // console.log(res.body.pChart)
-            // console.log(res.body.products)
+            // console.log(res.body)
             expect(res.body.days.length).to.be.equal(3)
             expect(Object.keys(res.body.pChart)).to.eql(['黑框美式', '皇后花園'])
             return done()
@@ -200,9 +196,7 @@ describe('# Admin::Dashboard Request', () => {
           .expect(200)
           .end((err, res) => {
             if (err) return done(err)
-            // console.log(res.body.days)
-            // console.log(res.body.uChart)
-            // console.log(res.body.users)
+            // console.log(res.body)
             expect(res.body.days.length).to.be.equal(2)
             expect(Object.keys(res.body.uChart)).to.eql(['nacho', 'kirwen'])
             return done()
@@ -215,26 +209,96 @@ describe('# Admin::Dashboard Request', () => {
           .expect(200)
           .end((err, res) => {
             if (err) return done(err)
-            //console.log(res.body)
-            console.log(res.body.days)
-            console.log(res.body.tChart)
-            console.log(res.body.tags)
-            // expect(res.body.days.length).to.be.equal(3)
-            // expect(Object.keys(res.body.pChart)).to.eql(['黑框美式', '皇后花園'])
+            // console.log(res.body)
+            expect(res.body.days.length).to.be.equal(2)
+            expect(Object.keys(res.body.tChart)).to.eql(['淺焙', '義式機'])
             return done()
           })
       })
     })
 
-    xcontext('monthly anaylsis report', () => {
+    after(async () => {
+      this.ensureAuthenticated.restore()
+      this.getUser.restore()
+      //tk.reset()
+      await db.Tag.destroy({ where: {}, truncate: true })
+      await db.Dish.destroy({ where: {}, truncate: true })
+      await db.User.destroy({ where: {}, force: true, truncate: true })
+      await db.UserPreferred.destroy({ where: {}, truncate: true })
+      await db.Order.destroy({ where: {}, force: true, truncate: true })
+      await db.DishCombination.destroy({ where: {}, truncate: true })
+      await db.DishAttachment.destroy({ where: {}, truncate: true })
+      await db.Profile.destroy({ where: {}, truncate: true })
+    })
+  })
 
-      xit('hot products/ hot tags/ hot members', (done) => {
+  context('go to Dashboard feature(monthly)', () => {
+    before(async () => {
+      this.ensureAuthenticated = sinon.stub(
+        helpers, 'ensureAuthenticated'
+      ).returns(true)
+      this.getUser = sinon.stub(
+        helpers, 'getUser'
+      ).returns({ id: 1, role: 'admin' })
+
+      tk.freeze(nowTime)
+      for (let i = 0; i < tags.length; i++) {
+        await db.Tag.create({ name: tags[i] })
+      }
+      for (let i = 0; i < orders.length; i++) {
+        let curretnTime
+        if (i < 2) {
+          curretnTime = time4
+        } else if (i >= 2 && i < 4) {
+          curretnTime = time5
+        } else {
+          curretnTime = time6
+        }
+        await db.Order.create({
+          quantity: orders[i].quantity, amount: orders[i].amount, createdAt: curretnTime,
+          memo: orders[i].memo, isTakingAway: orders[i].isTakingAway, UserId: orders[i].UserId
+        })
+        for (let j = 0; j < orders[i].dishes.length; j++) {
+          await db.DishCombination.create({
+            OrderId: i + 1, DishId: orders[i].dishes[j].id,
+            perQuantity: orders[i].dishes[j].quantity, perAmount: orders[i].dishes[j].price,
+            createdAt: curretnTime
+          })
+        }
+      }
+      for (let i = 0; i < menu.length; i++) {
+        dish = await db.Dish.create({ name: menu[i].name, price: menu[i].price, CategoryId: menu[i].CategoryId })
+        for (let j = 0; j < menu[i].tags.length; j++) {
+          await db.DishAttachment.create({ TagId: menu[i].tags[j].id, DishId: i + 1 })
+        }
+      }
+      for (let i = 0; i < userPreferred.length; i++) {
+        let currentTime
+        if (i < userPreferred.length / 2) currentTime = time4
+        else currentTime = time6
+        await db.UserPreferred.create({
+          TagId: userPreferred[i].TagId,
+          UserId: userPreferred[i].UserId,
+          createdAt: currentTime
+        })
+      }
+      await db.User.create(member1)
+      await db.User.create(member2)
+      await db.User.create(member3)
+      await db.Profile.create(profi1)
+      await db.Profile.create(profi2)
+    })
+
+    context('monthly anaylsis report', () => {
+
+      it('hot products/ hot tags/ hot members', (done) => {
         request(app)
           .get('/api/admin/dashboard/pieChart?range=monthly')
           .expect(200)
           .end((err, res) => {
             if (err) return done(err)
-            // console.log(res.body.data)
+            // console.log(res.body)
+
             // console.log(res.body.data2)
             // console.log(res.body.hotProducts[0])
             // console.log(res.body.hotMembers[0])
@@ -249,22 +313,53 @@ describe('# Admin::Dashboard Request', () => {
           })
       })
 
-      xit('hot products growing', (done) => {
+      it('products growing', (done) => {
         request(app)
-          .get('/api/admin/dashboard/lineChart?range=monthly&id=1&id=7')
+          .get('/api/admin/dashboard/lineChart?type=product&range=monthly&id=1&id=7')
           .expect(200)
           .end((err, res) => {
             if (err) return done(err)
-            // console.log(res.body.days)
+            // console.log(nowTime) // 將時間鎖住
+            // console.log(time1)
+            // console.log(time2)
+            // console.log(time3)
+            // console.log(res.body)
             // console.log(res.body.pChart)
-            //console.log(res.body.products)
+            // console.log(res.body.products)
             expect(res.body.days.length).to.be.equal(3)
             expect(Object.keys(res.body.pChart)).to.eql(['黑框美式', '皇后花園'])
             return done()
           })
       })
-    })
 
+      it('times of member visiting growing', (done) => {
+        request(app)
+          .get('/api/admin/dashboard/lineChart?type=user&range=monthly&id=1&id=2')
+          .expect(200)
+          .end((err, res) => {
+            if (err) return done(err)
+            // console.log(res.body)
+            // console.log(res.body.uChart)
+            // console.log(res.body.users)
+            expect(res.body.days.length).to.be.equal(3)
+            expect(Object.keys(res.body.uChart)).to.eql(['null', 'nacho'])
+            return done()
+          })
+      })
+
+      it('tags of member preferred growing', (done) => {
+        request(app)
+          .get('/api/admin/dashboard/lineChart?type=tag&range=monthly&id=1&id=10')
+          .expect(200)
+          .end((err, res) => {
+            if (err) return done(err)
+            // console.log(res.body)
+            expect(res.body.days.length).to.be.equal(2)
+            expect(Object.keys(res.body.tChart)).to.eql(['淺焙', '義式機'])
+            return done()
+          })
+      })
+    })
 
     after(async () => {
       this.ensureAuthenticated.restore()

--- a/server/test/requests/Dashboard.spec.js
+++ b/server/test/requests/Dashboard.spec.js
@@ -121,11 +121,30 @@ describe('# Admin::Dashboard Request', () => {
       await db.Profile.create(profi2)
     })
 
+    xcontext('get basic info report', () => {
+      it("current member numbers/ today's order numbers/ current order numbers", (done) => {
+        request(app)
+          .get('/api/admin/dashboard')
+          .expect(200)
+          .end((err, res) => {
+            if (err) return done(err)
+            console.log(res.body)
+            // expect(res.body.hotProducts[0]).to.eql({ id: 1, name: '黑框美式', count: 4 })
+            // expect(res.body.hotProducts.length).to.be.equal(5)
+            // expect(res.body.hotMembers[0]).to.eql({ id: 2, name: 'nacho', count: 4 })
+            // expect(res.body.hotMembers.length).to.be.equal(2)
+            // expect(res.body.hotTags[0]).to.eql({ id: 9, name: '手沖', count: 10 })
+            // expect(res.body.hotTags.length).to.be.equal(5)
+            return done()
+          })
+      })
+    })
+
     context('weekly anaylsis report', () => {
 
-      it('hot products/ hot tags/ hot members', (done) => {
+      xit('hot products/ hot tags/ hot members', (done) => {
         request(app)
-          .get('/api/admin/dashboard?range=weekly')
+          .get('/api/admin/dashboard/pieChart?range=weekly')
           .expect(200)
           .end((err, res) => {
             if (err) return done(err)
@@ -148,13 +167,13 @@ describe('# Admin::Dashboard Request', () => {
 
       it('hot products growing', (done) => {
         request(app)
-          .get('/api/admin/dashboard/lineChart?id=1&id=7')
+          .get('/api/admin/dashboard/lineChart?range=weekly&id=1&id=7')
           .expect(200)
           .end((err, res) => {
             if (err) return done(err)
-            // console.log(res.body.days)
-            // console.log(res.body.pChart)
-            //console.log(res.body.products)
+            console.log(res.body.days)
+            console.log(res.body.pChart)
+            console.log(res.body.products)
             expect(res.body.days.length).to.be.equal(3)
             expect(Object.keys(res.body.pChart)).to.eql(['黑框美式', '皇后花園'])
             return done()
@@ -162,11 +181,11 @@ describe('# Admin::Dashboard Request', () => {
       })
     })
 
-    context('monthly anaylsis report', () => {
+    xcontext('monthly anaylsis report', () => {
 
       it('hot products/ hot tags/ hot members', (done) => {
         request(app)
-          .get('/api/admin/dashboard?range=monthly')
+          .get('/api/admin/dashboard/pieChart?range=monthly')
           .expect(200)
           .end((err, res) => {
             if (err) return done(err)

--- a/server/test/requests/Dish.spec.js
+++ b/server/test/requests/Dish.spec.js
@@ -37,12 +37,13 @@ describe('# Admin::Dish Request', () => {
       request(app)
         .get('/api/admin/dishes?categoryId=2')
         .set('Accept', 'application/json')
+        .expect(200)
         .end(function (err, res) {
           if (err) return done(err);
-          res.status.should.be.eql(200)
-          res.text.should.include('americana')
-          res.text.should.include('latei')
+          // res.text.should.include('americana')
+          // res.text.should.include('latei')
           expect(res.body).to.have.property('dishes')
+          expect(res.body.dishes.length).to.be.equal(2)
           return done();
         });
     })
@@ -54,8 +55,7 @@ describe('# Admin::Dish Request', () => {
           name: '紅茶',
           price: 40,
           CategoryId: 1,
-          tags: [{ id: 1 }, { id: 2 }],
-          //option: { sugar: ["no", "30%", "half", "70%", "full"] }
+          tags: [{ id: 1 }, { id: 2 }]
         })
         .expect(200)
         .end(async (err, res) => {
@@ -75,7 +75,7 @@ describe('# Admin::Dish Request', () => {
         .expect(200)
         .end(async (err, res) => {
           if (err) return done(err)
-          //console.log(res.body.dish.hasTags)
+          console.log(res.body.dish)
           expect(res.body.dish.name).to.be.equal('紅茶')
           expect(res.body.dish.price).to.be.equal(40)
           expect(res.body.dish.Category.name).to.be.equal('new')

--- a/server/test/requests/Member.spec.js
+++ b/server/test/requests/Member.spec.js
@@ -36,6 +36,11 @@ const order2 = {
   isTakingAway: true,
   UserId: 3
 }
+const dishCombos = [
+  { OrderId: 1, DishId: 1, perQuantity: 2, perAmount: 60 }, { OrderId: 1, DishId: 2, perQuantity: 2, perAmount: 80 },
+  { OrderId: 2, DishId: 1, perQuantity: 2, perAmount: 60 }, { OrderId: 2, DishId: 2, perQuantity: 1, perAmount: 40 }]
+const dishes = [{ name: 'mocha', price: 30, CategoryId: 1 }, { name: 'latie', price: 40, CategoryId: 1 }]
+
 
 describe('# Admin::Member request', () => {
 
@@ -49,10 +54,7 @@ describe('# Admin::Member request', () => {
         this.getUser = sinon.stub(
           helper, 'getUser'
         ).returns({ id: 1, role: 'admin' })
-        await db.User.destroy({ where: {}, force: true, truncate: true })
-        await db.Profile.destroy({ where: {}, truncate: true })
-        await db.Tag.destroy({ where: {}, truncate: true })
-        await db.Order.destroy({ where: {}, force: true, truncate: true })
+
         await db.User.create(admin)
         await db.User.create(member1)
         await db.User.create(member2)
@@ -65,6 +67,12 @@ describe('# Admin::Member request', () => {
         await db.UserPreferred.create({ UserId: 1, TagId: 1 })
         await db.UserPreferred.create({ UserId: 1, TagId: 2 })
         await db.UserPreferred.create({ UserId: 3, TagId: 1 })
+        for (let i = 0; i < dishCombos.length; i++) {
+          await db.DishCombination.create(dishCombos[i])
+        }
+        for (let i = 0; i < dishes.length; i++) {
+          await db.Dish.create(dishes[i])
+        }
       })
 
       it('should get a specific user who is not admin', (done) => {
@@ -97,8 +105,10 @@ describe('# Admin::Member request', () => {
           .get('/api/admin/members/3/orders')
           .expect(200)
           .end((err, res) => {
-            //console.log(res.body)
+            // console.log(res.body.orders)
             expect(res.body.orders.length).to.be.equal(2)
+            expect(res.body.orders[0].sumOfDishes.length).to.be.equal(2)
+            expect(res.body.orders[1].sumOfDishes.length).to.be.equal(2)
             return done()
           })
       })
@@ -206,6 +216,8 @@ describe('# Admin::Member request', () => {
         await db.Tag.destroy({ where: {}, truncate: true })
         await db.Order.destroy({ where: {}, force: true, truncate: true })
         await db.UserPreferred.destroy({ where: {}, truncate: true })
+        await db.DishCombination.destroy({ where: {}, truncate: true })
+        await db.Dish.destroy({ where: {}, truncate: true })
       })
     })
 

--- a/server/test/requests/User.spec.js
+++ b/server/test/requests/User.spec.js
@@ -131,7 +131,7 @@ describe('# Admin::User request', () => {
           })
       })
 
-      it('should get current user', (done) => {
+      xit('should get current user', (done) => {
         request(app)
           .get('/api/admin/user')
           .set('Authorization', `bearer ${testToken}`)


### PR DESCRIPTION
1.  新增與測試折線圖API
get api/admin/dashboard/lineChart?type=product&range=weekly&id=1&id=2 (針對菜單項目個別的成長)
get api/admin/dashboard/lineChart?type=user&range=weekly&id=1&id=2 (針對會員個別的成長)
get api/admin/dashboard/lineChart?type=tag&range=weekly&id=1&id=2 (針對收藏標籤個別的成長)
2. 新增與測試圓餅圖API以及基本營業資訊的API
get api/admin/dashboard/pieChart?range=weekly
get api/admin/dashboard
【補充】
range可分為weekly和monthly
3.  補充會員前台的API
get api/member/categories
get api/member/dishes?categoryId=1
2.  增加菜單品項的name 給getMemberOrders
4.  getCurrentUser 的API位置改成 get api/user